### PR TITLE
Fix incorrect `WHERE` documentation

### DIFF
--- a/where.md
+++ b/where.md
@@ -50,7 +50,7 @@ db.Query("Users").WhereFalse("IsActive").OrWhereNull("LastActivityDate");
 ```
 
 ```sql
-SELECT * FROM [Users] WHERE [IsActive] = 0 AND [LastActivityDate] IS NULL
+SELECT * FROM [Users] WHERE [IsActive] = 0 OR [LastActivityDate] IS NULL
 ```
 
 > **Note:** the above methods will put the values literally in the generated sql and do not use parameter bindings techniques.


### PR DESCRIPTION
When you run
```cs
db.Query("Users").WhereFalse("IsActive").OrWhereNull("LastActivityDate");
```
in the playground via the "Try it" button, the playground outputs
```sql
SELECT * FROM [Users] WHERE [IsActive] = cast(0 as bit) OR [LastActivityDate] IS NULL
```
while the documentation here says
```sql
SELECT * FROM [Users] WHERE [IsActive] = 0 AND [LastActivityDate] IS NULL
```

The `cast` part can be left out but the `OR` mistake shouldn't.