### PR TITLE
Fix typos

### DIFF
--- a/execution/setup.md
+++ b/execution/setup.md
@@ -76,7 +76,7 @@ builder.Services.AddTransient<QueryFactory>((e) =>
         "Host=localhost;Port=3306;User=user;Password=secret;Database=Users;SslMode=None"
     );
 
-    var compiler = new MySqlServerCompiler();
+    var compiler = new MySqlCompiler();
 
     return new QueryFactory(connection, compiler);
 


### PR DESCRIPTION
<img width="654" alt="スクリーンショット 2022-08-21 18 34 20" src="https://user-images.githubusercontent.com/48668579/185784860-092d926e-d3b7-4ba0-8b91-4e594d4e2b67.png">



MySqlServerCompiler was not found in [sqlkata/querybuilder](https://github.com/sqlkata/querybuilder), so it was changed to MySqlCompiler